### PR TITLE
修正

### DIFF
--- a/app/controllers/prototypes_controller.rb
+++ b/app/controllers/prototypes_controller.rb
@@ -13,7 +13,7 @@ class PrototypesController < ApplicationController
     if @prototype.save
       redirect_to root_path, notice: 'You succeeded in posting'
     else
-      render :new, alert: 'You failed in posting'
+      redirect_to new_prototype_path, alert: @prototype.errors.full_messages
     end
   end
   def show
@@ -25,14 +25,14 @@ class PrototypesController < ApplicationController
     if @prototype.update(proto_params)
       redirect_to root_path, notice: 'You suceeded in updating'
     else
-      render :edit, alert: 'You failed in updating'
+      redirect_to edit_prototype_path(@prototype), alert: @prototype.errors.full_messages
     end
   end
   def destroy
     if @prototype.destroy
       redirect_to root_path, notice: 'You succeeded in deleting'
     else
-      redirect_to root_path, alert: 'You failed in deleting'
+      redirect_to root_path, alert: @prototype.errors.full_messages
     end
   end
   private

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,15 @@
 class UsersController < ApplicationController
   def edit
-     redirect_to prototypes_index_path unless current_user.id == params[:id].to_i
      @user = User.find(params[:id])
+     redirect_to prototypes_index_path unless current_user.id == @user.id
   end
 
   def update
-    user = User.find(params[:id])
-    if user.update(user_params)
-      redirect_to root_path, success: "You succeeded to edit your profile"
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      redirect_to root_path, notice: "You succeeded to edit your profile"
     else
-      render edit_user_path, warning: "You failed to edit your profile"
+      redirect_to edit_user_path(@user), alert: @user.errors.full_messages
     end
   end
 

--- a/app/views/layouts/_flash.html.haml
+++ b/app/views/layouts/_flash.html.haml
@@ -1,3 +1,13 @@
 - flash.each do |alert_type, value|
   - alert_type = alert_type == 'notice' ? 'info' : 'danger'
-  = content_tag :div, value, class: "alert alert-#{alert_type}"
+  - if alert_type == 'danger'
+    .alert.alert-danger
+      %ul
+        - value.each do |msg|
+          %li
+            = msg
+  - else
+    .alert.alert-info
+      = value
+
+

--- a/app/views/layouts/_prototype.html.haml
+++ b/app/views/layouts/_prototype.html.haml
@@ -1,25 +1,26 @@
 .col-sm-4.col-md-3.proto-content
   .thumbnail
-    - if current_user.id == proto.user_id && user_signed_in?
-      .dropdown.drop_menu_location
-        %button.btn.btn-default.dropdown-toggle{ type: "button", data: {toggle: "dropdown"}, area: {expanded: false}}
-          Action
-        %ul.dropdown-menu{ aria: {labelledby: "dropdownMenu1"}}
-          %li
-            = link_to 'Delete', prototype_path(proto), method: :delete
-          %li
-            = link_to 'Edit', edit_prototype_path(proto)
-      = link_to prototype_path(proto) do
-        = image_tag(proto.images.main.first.content)
-      .caption
-        %h3= proto.title
-        .proto-meta
-          .proto-user
-            = link_to "by #{proto.user.name}", user_path(proto.user)
-          .proto-posted
-            = proto.created_at.strftime("%Y年%m月%d日")
-        %ul.proto-tag-list.list-inline
-          %li
-            %a{href: "#", class: "btn btn-default"} iPad
-          %li
-            %a{href: "#", class: "btn btn-default"} wireframe
+    - if user_signed_in?
+      - if current_user.id == proto.user_id
+        .dropdown.drop_menu_location
+          %button.btn.btn-default.dropdown-toggle{ type: "button", data: {toggle: "dropdown"}, area: {expanded: false}}
+            Action
+          %ul.dropdown-menu{ aria: {labelledby: "dropdownMenu1"}}
+            %li
+              = link_to 'Delete', prototype_path(proto), method: :delete
+            %li
+              = link_to 'Edit', edit_prototype_path(proto)
+    = link_to prototype_path(proto) do
+      = image_tag(proto.images.main.first.content)
+    .caption
+      %h3= proto.title
+      .proto-meta
+        .proto-user
+          = link_to "by #{proto.user.name}", user_path(proto.user)
+        .proto-posted
+          = proto.created_at.strftime("%Y年%m月%d日")
+      %ul.proto-tag-list.list-inline
+        %li
+          %a{href: "#", class: "btn btn-default"} iPad
+        %li
+          %a{href: "#", class: "btn btn-default"} wireframe


### PR DESCRIPTION
# what

noticeなどの情報を渡す必要があるため、renderをredirect_to に変更
エラーメッセージをすべてのところで出るように設定
ユーザーがサインインていないとアクセスできない問題を修正
# why

エラーメッセージをすべてに適応させるため
エラー解決
